### PR TITLE
Batch processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,15 @@
 
 ## Purpose
 
-We provides a utility to merge a large number of VCF files (too many to open at once) incrementally, that only use as
+We provides a utility to merge a large number of VCF files (possibly too many to open at once) incrementally, that only use as
 much memory as each line in one of the input files takes (so the fewer samples you have in each of the input files, the
 less memory you need).
 
 ## Usage
 
 ### In Python
+
+#### If the number of input files is small (can be opened all at once)
 
 ```python
 from contextlib import ExitStack
@@ -21,6 +23,18 @@ with ExitStack() as stack:
     files = map(lambda fname: stack.enter_context(open(fname)), filenames)
     with open(output_path) as outfile:
         ivcfmerge(files, outfile)
+```
+
+#### If the number of input files is big (cannot be opened all at once)
+
+```python
+from ivcfmerge.batch import ivcfmerge_batch
+
+filenames = [...]    # List/iterator of relative/absolute paths to input files
+output_path = '...'  # Where to write the merged VCF to
+batch_size = 1000    # How many files to open and merge at once
+
+ivcfmerge_batch(filenames, output_path, batch_size)
 ```
 
 ## Batch size

--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ less memory you need).
 from contextlib import ExitStack
 from ivcfmerge import ivcfmerge
 
-filenames = [...]    # List of relative/absolute paths to input files
+filenames = [...]    # List/iterator of relative/absolute paths to input files
 output_path = '...'  # Where to write the merged VCF to
 
 with ExitStack() as stack:
-    files = [stack.enter_context(open(fname)) for fname in filenames]
+    files = map(lambda fname: stack.enter_context(open(fname)), filenames)
     with open(output_path) as outfile:
         ivcfmerge(files, outfile)
 ```

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 ## Purpose
 
-We provides a utility to merge a large number of VCF files (possibly too many to open at once) incrementally, that only use as
-much memory as each line in one of the input files takes (so the fewer samples you have in each of the input files, the
-less memory you need).
+We provides a utility to merge a large number of VCF files (possibly too many to open at once) incrementally, that only
+use as much memory as each line in one of the input files takes (so the fewer samples you have in each of the input
+files, the less memory you need).
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@
 ## Purpose
 
 We provides a utility to merge a large number of VCF files (possibly too many to open at once) incrementally, that only
-use as much memory as each line in one of the input files takes (so the fewer samples you have in each of the input
-files, the less memory you need).
+use almost as much memory as one merged line takes.
 
 ## Usage
 
@@ -28,7 +27,7 @@ with ExitStack() as stack:
 #### If the number of input files is big (cannot be opened all at once)
 
 ```python
-from ivcfmerge.batch import ivcfmerge_batch
+from ivcfmerge import ivcfmerge_batch
 
 filenames = [...]    # List/iterator of relative/absolute paths to input files
 output_path = '...'  # Where to write the merged VCF to

--- a/README.md
+++ b/README.md
@@ -22,3 +22,10 @@ with ExitStack() as stack:
     with open(output_path) as outfile:
         ivcfmerge(files, outfile)
 ```
+
+## Batch size
+
+An important parameter for this utility is `batch_size`, which indicates how many files to open and merge each batch,
+since the total number of input files can exceed the number of open files allowed by the OS.
+
+The default value for this parameter is 1000.

--- a/ivcfmerge/__init__.py
+++ b/ivcfmerge/__init__.py
@@ -1,1 +1,2 @@
 from .core import ivcfmerge
+from .batch import ivcfmerge_batch

--- a/ivcfmerge/batch.py
+++ b/ivcfmerge/batch.py
@@ -1,4 +1,3 @@
-import shutil
 from contextlib import ExitStack
 from queue import Queue
 from tempfile import NamedTemporaryFile
@@ -7,24 +6,31 @@ from . import ivcfmerge
 
 
 def ivcfmerge_batch(input_paths, output_path, batch_size=1000):
-    work_queue = Queue()
-    [work_queue.put(item) for item in input_paths]
+    if batch_size < 2 or batch_size > len(input_paths):
+        batch_size = len(input_paths)
 
-    last_tmp_filename = ''
+    if batch_size == len(input_paths):
+        batch = input_paths
+    else:
+        work_queue = Queue()
+        [work_queue.put(item) for item in input_paths]
 
-    while True:
-        batch = []
-        while not work_queue.empty() and len(batch) < batch_size:
-            batch.append(work_queue.get_nowait())
+        while True:
+            batch = []
+            while not work_queue.empty() and len(batch) < batch_size:
+                batch.append(work_queue.get_nowait())
 
-        if len(batch) == 1:
-            break
+            if len(batch) < batch_size or work_queue.empty():
+                break
 
-        with ExitStack() as stack, open(NamedTemporaryFile().name, 'w+') as tmp_outfile:
-            infiles = map(lambda p: stack.enter_context(open(p)), batch)
-            ivcfmerge(infiles, tmp_outfile)
+            tmp_filename = NamedTemporaryFile().name
+            _ivcfmerge(batch, tmp_filename)
+            work_queue.put(tmp_filename)
 
-            work_queue.put(tmp_outfile.name)
-            last_tmp_filename = tmp_outfile.name
+    _ivcfmerge(batch, output_path)
 
-    shutil.copyfile(last_tmp_filename, output_path)
+
+def _ivcfmerge(input_paths, output_path):
+    with ExitStack() as stack, open(output_path, 'w+') as outfile:
+        infiles = map(lambda p: stack.enter_context(open(p)), input_paths)
+        ivcfmerge(infiles, outfile)

--- a/ivcfmerge/batch.py
+++ b/ivcfmerge/batch.py
@@ -1,0 +1,30 @@
+import shutil
+from contextlib import ExitStack
+from queue import Queue
+from tempfile import NamedTemporaryFile
+
+from . import ivcfmerge
+
+
+def ivcfmerge_batch(input_paths, output_path, batch_size=1000):
+    work_queue = Queue()
+    [work_queue.put(item) for item in input_paths]
+
+    last_tmp_filename = ''
+
+    while True:
+        batch = []
+        while not work_queue.empty() and len(batch) < batch_size:
+            batch.append(work_queue.get_nowait())
+
+        if len(batch) == 1:
+            break
+
+        with ExitStack() as stack, open(NamedTemporaryFile().name, 'w+') as tmp_outfile:
+            infiles = map(lambda p: stack.enter_context(open(p)), batch)
+            ivcfmerge(infiles, tmp_outfile)
+
+            work_queue.put(tmp_outfile.name)
+            last_tmp_filename = tmp_outfile.name
+
+    shutil.copyfile(last_tmp_filename, output_path)

--- a/ivcfmerge/batch.py
+++ b/ivcfmerge/batch.py
@@ -13,7 +13,8 @@ def ivcfmerge_batch(input_paths, output_path, batch_size=1000):
         batch = input_paths
     else:
         work_queue = Queue()
-        [work_queue.put(item) for item in input_paths]
+        for item in input_paths:
+            work_queue.put(item)
 
         while True:
             batch = []

--- a/ivcfmerge/core.py
+++ b/ivcfmerge/core.py
@@ -6,13 +6,16 @@ from .utils import assign_file_index_to_lines, write_vcf
 
 
 def ivcfmerge(infiles, outfile):
+    infiles_1, infiles_2 = itertools.tee(infiles)
+    n_infiles = len(list(infiles_1))
+
     # Create an iterator through the files with their indices
     # [
     #  (0, [line, line, ...]),  # file 1
     #  (1, [line, line, ...]),  # file 2
     #  ...
     # ]
-    file_enumerator = enumerate(infiles)
+    file_enumerator = enumerate(infiles_2)
 
     # Insert to each line of each file their file's index
     # [
@@ -79,7 +82,7 @@ def ivcfmerge(infiles, outfile):
     filtered = apply_filters(transformed)
 
     # Actually iterate the lines and write them
-    write_vcf(filtered, outfile, len(infiles))
+    write_vcf(filtered, outfile, n_infiles)
 
 
 def transform(file_idx, line):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,16 @@
+import pytest
+
+
+def _input_paths():
+    return [
+        'tests/data/input/1.vcf',
+        'tests/data/input/2.vcf',
+        'tests/data/input/3.vcf',
+        'tests/data/input/4.vcf',
+        'tests/data/input/5.vcf',
+        'tests/data/input/6.vcf',
+    ]
+
+
+# We need to call _input_paths directly sometimes, hence the explicit but different named fixture
+input_paths = pytest.fixture(_input_paths)

--- a/tests/test_ivcfmerge.py
+++ b/tests/test_ivcfmerge.py
@@ -16,7 +16,7 @@ def test_merging_example_input():
     ref_merged_path = 'tests/data/ref/merged.vcf'
 
     with ExitStack() as stack:
-        files = [stack.enter_context(open(fn)) for fn in input_paths]
+        files = map(lambda fn: stack.enter_context(open(fn)), input_paths)
         with TemporaryFile('w+') as outfile, open(ref_merged_path, 'r') as expected:
             ivcfmerge(files, outfile)
 

--- a/tests/test_ivcfmerge.py
+++ b/tests/test_ivcfmerge.py
@@ -4,15 +4,7 @@ from tempfile import TemporaryFile
 from ivcfmerge import ivcfmerge
 
 
-def test_merging_example_input():
-    input_paths = [
-        'tests/data/input/1.vcf',
-        'tests/data/input/2.vcf',
-        'tests/data/input/3.vcf',
-        'tests/data/input/4.vcf',
-        'tests/data/input/5.vcf',
-        'tests/data/input/6.vcf',
-    ]
+def test_merging_example_input(input_paths):
     ref_merged_path = 'tests/data/ref/merged.vcf'
 
     with ExitStack() as stack:
@@ -22,3 +14,30 @@ def test_merging_example_input():
 
             outfile.seek(0)
             assert outfile.read() == expected.read()
+
+
+def test_single_input():
+    input_paths = [
+        'tests/data/input/1.vcf',
+    ]
+    ref_merged_path = 'tests/data/input/1.vcf'
+
+    with ExitStack() as stack:
+        files = map(lambda fn: stack.enter_context(open(fn)), input_paths)
+        with TemporaryFile('w+') as outfile, open(ref_merged_path, 'r') as expected:
+            ivcfmerge(files, outfile)
+
+            outfile.seek(0)
+            assert outfile.read() == expected.read()
+
+
+def test_empty_input_list():
+    input_paths = []
+
+    with ExitStack() as stack:
+        files = map(lambda fn: stack.enter_context(open(fn)), input_paths)
+        with TemporaryFile('w+') as outfile:
+            ivcfmerge(files, outfile)
+
+            outfile.seek(0)
+            assert outfile.read() == ''

--- a/tests/test_ivcfmerge_batch.py
+++ b/tests/test_ivcfmerge_batch.py
@@ -1,0 +1,25 @@
+from tempfile import NamedTemporaryFile
+
+from hypothesis import given, strategies as st
+
+from ivcfmerge.batch import ivcfmerge_batch
+
+
+@given(batch_size=st.integers(min_value=2))
+def test_merging_example_input(batch_size):
+    input_paths = [
+        'tests/data/input/1.vcf',
+        'tests/data/input/2.vcf',
+        'tests/data/input/3.vcf',
+        'tests/data/input/4.vcf',
+        'tests/data/input/5.vcf',
+        'tests/data/input/6.vcf',
+    ]
+
+    with NamedTemporaryFile('w+') as outfile:
+        ivcfmerge_batch(input_paths, outfile.name, batch_size)
+        output = outfile.read()
+
+        assert output.count('##') == 11
+        assert output.count('#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\t') == 1
+        assert output.count('site') == len(input_paths)

--- a/tests/test_ivcfmerge_batch.py
+++ b/tests/test_ivcfmerge_batch.py
@@ -35,3 +35,21 @@ def test_out_of_bound_batch_sizes_yield_the_same_output_as_normal_ivcfmerge(batc
         output = outfile.read()
 
     assert output == expected
+
+
+@given(batch_size=st.integers())
+def test_single_input_yields_the_same_output_as_normal_ivcfmerge(batch_size):
+    input_paths = ['tests/data/input/1.vcf']
+
+    with ExitStack() as stack:
+        files = map(lambda fn: stack.enter_context(open(fn)), input_paths)
+        with TemporaryFile('w+') as outfile:
+            ivcfmerge(files, outfile)
+            outfile.seek(0)
+            expected = outfile.read()
+
+    with NamedTemporaryFile('w+') as outfile:
+        ivcfmerge_batch(input_paths, outfile.name, batch_size)
+        output = outfile.read()
+
+    assert output == expected

--- a/tests/test_ivcfmerge_batch.py
+++ b/tests/test_ivcfmerge_batch.py
@@ -1,21 +1,14 @@
-from tempfile import NamedTemporaryFile
+from contextlib import ExitStack
+from tempfile import NamedTemporaryFile, TemporaryFile
 
 from hypothesis import given, strategies as st
 
-from ivcfmerge.batch import ivcfmerge_batch
+from ivcfmerge import ivcfmerge_batch, ivcfmerge
+from tests.conftest import _input_paths
 
 
 @given(batch_size=st.integers(min_value=2))
-def test_merging_example_input(batch_size):
-    input_paths = [
-        'tests/data/input/1.vcf',
-        'tests/data/input/2.vcf',
-        'tests/data/input/3.vcf',
-        'tests/data/input/4.vcf',
-        'tests/data/input/5.vcf',
-        'tests/data/input/6.vcf',
-    ]
-
+def test_merging_example_input(batch_size, input_paths):
     with NamedTemporaryFile('w+') as outfile:
         ivcfmerge_batch(input_paths, outfile.name, batch_size)
         output = outfile.read()
@@ -23,3 +16,22 @@ def test_merging_example_input(batch_size):
         assert output.count('##') == 11
         assert output.count('#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\t') == 1
         assert output.count('site') == len(input_paths)
+
+
+@given(batch_size=st.one_of(
+    st.integers(max_value=1),
+    st.integers(min_value=len(_input_paths()))
+))
+def test_out_of_bound_batch_sizes_yield_the_same_output_as_normal_ivcfmerge(batch_size, input_paths):
+    with ExitStack() as stack:
+        files = map(lambda fn: stack.enter_context(open(fn)), input_paths)
+        with TemporaryFile('w+') as outfile:
+            ivcfmerge(files, outfile)
+            outfile.seek(0)
+            expected = outfile.read()
+
+    with NamedTemporaryFile('w+') as outfile:
+        ivcfmerge_batch(input_paths, outfile.name, batch_size)
+        output = outfile.read()
+
+    assert output == expected


### PR DESCRIPTION
This PR adds the batch processing capability to ivcfmerge, so that it can process large number of input files that exceed the OS' open file limit.

Updated README:

# ivcfmerge: Incremental VCF merge

## Purpose

We provides a utility to merge a large number of VCF files (possibly too many to open at once) incrementally, that only use as much memory as each line in one of the input files takes (so the fewer samples you have in each of the input files, the less memory you need).

## Usage

### In Python

#### If the number of input files is small (can be opened all at once)

```python
from contextlib import ExitStack
from ivcfmerge import ivcfmerge

filenames = [...]    # List/iterator of relative/absolute paths to input files
output_path = '...'  # Where to write the merged VCF to

with ExitStack() as stack:
    files = map(lambda fname: stack.enter_context(open(fname)), filenames)
    with open(output_path) as outfile:
        ivcfmerge(files, outfile)
```

#### If the number of input files is big (cannot be opened all at once)

```python
from ivcfmerge.batch import ivcfmerge_batch

filenames = [...]    # List/iterator of relative/absolute paths to input files
output_path = '...'  # Where to write the merged VCF to
batch_size = 1000    # How many files to open and merge at once

ivcfmerge_batch(filenames, output_path, batch_size)
```

## Batch size

An important parameter for this utility is `batch_size`, which indicates how many files to open and merge each batch,
since the total number of input files can exceed the number of open files allowed by the OS.

The default value for this parameter is 1000.
