### PR TITLE
CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,16 +4,21 @@
 
 We provides a utility to merge a large number of VCF files (possibly too many to open at once) incrementally, that only use almost as much memory as one merged line takes.
 
-## 2. Usage
+## 2 Important assumptions:
+
+* All input VCFs are positionally sorted, and the values for the FILTER column of each position are the same for all samples.
+* All input VCFs have the same headers and the same number of positions.
+
+## 3. Usage
 
 You can use the utility as either:
 
 * [A Python library](#python-usage)
 * [A Python script](#cli-usage)
 
-### <a name="python-usage">2.1 In Python</a>
+### <a name="python-usage">3.1 In Python</a>
 
-#### 2.1.1 If the number of input files is small (can be opened all at once)
+#### 3.1.1 If the number of input files is small (can be opened all at once)
 
 ```python
 from contextlib import ExitStack
@@ -28,7 +33,7 @@ with ExitStack() as stack:
         ivcfmerge(files, outfile)
 ```
 
-#### 2.1.2 If the number of input files is big (cannot be opened all at once)
+#### 3.1.2 If the number of input files is big (cannot be opened all at once)
 
 ```python
 from ivcfmerge import ivcfmerge_batch
@@ -40,7 +45,7 @@ batch_size = 1000    # How many files to open and merge at once
 ivcfmerge_batch(filenames, output_path, batch_size)
 ```
 
-##### 2.1.2.1 You may also need to specify a temporary directory
+##### 3.1.2.1 You may also need to specify a temporary directory
 
 That has at least as much space as that occupied by the input files to store intermediate results, in the batch processing version.
 
@@ -51,9 +56,9 @@ temp_dir = '...'  # for example, a directory on a mounted disk like /mnt/big_dis
 ivcfmerge_batch(filenames, output_path, batch_size, temp_dir)
 ```
 
-### <a name="cli-usage">2.2 Command line interface</a>
+### <a name="cli-usage">3.2 Command line interface</a>
 
-#### 2.2.1 If the number of input files is small (can be opened all at once)
+#### 3.2.1 If the number of input files is small (can be opened all at once)
 
 ```shell script
 # Prepare a file of paths to input VCF files
@@ -65,7 +70,7 @@ ivcfmerge_batch(filenames, output_path, batch_size, temp_dir)
 > python ivcfmerge.py input_paths.txt path/to/output/file
 ```
 
-#### 2.2.2 If the number of input files is big (cannot be opened all at once) 
+#### 3.2.2 If the number of input files is big (cannot be opened all at once) 
 
 ```shell script
 # Prepare a file of paths to input VCF files
@@ -77,7 +82,7 @@ ivcfmerge_batch(filenames, output_path, batch_size, temp_dir)
 > python ivcfmerge_batch.py --batch-size 1000 input_paths.txt path/to/output/file
 ```
 
-##### 2.1.2.1 You may also need to specify a temporary directory
+##### 3.2.2.1 You may also need to specify a temporary directory
 
 That has at least as much space as that occupied by the input files to store intermediate results, in the batch processing version.
 
@@ -87,15 +92,15 @@ That has at least as much space as that occupied by the input files to store int
 > python ivcfmerge_batch.py --batch-size 1000 --temp-dir /path/to/tmp/dir input_paths.txt path/to/output/file
 ```
 
-## 3. Important parameters
+## 4. Important parameters
  
-### 3.1 `batch_size`
+### 4.1 `batch_size`
 
 Indicates how many files to open and merge each batch, for the batch processing version.
 
 The default value for this parameter is 1000.
 
-### 3.2 `temp_dir`
+### 4.2 `temp_dir`
 
 For the batch processing version, the utility needs to store the intermediate results somewhere with as much space as the total space occupied by the input files.
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,19 @@
 # ivcfmerge: Incremental VCF merge
 
-## Purpose
+## 1. Purpose
 
-We provides a utility to merge a large number of VCF files (possibly too many to open at once) incrementally, that only
-use almost as much memory as one merged line takes.
+We provides a utility to merge a large number of VCF files (possibly too many to open at once) incrementally, that only use almost as much memory as one merged line takes.
 
-## Usage
+## 2. Usage
 
-### In Python
+You can use the utility as either:
 
-#### If the number of input files is small (can be opened all at once)
+* [A Python library](#python-usage)
+* [A Python script](#cli-usage)
+
+### <a name="python-usage">2.1 In Python</a>
+
+#### 2.1.1 If the number of input files is small (can be opened all at once)
 
 ```python
 from contextlib import ExitStack
@@ -24,7 +28,7 @@ with ExitStack() as stack:
         ivcfmerge(files, outfile)
 ```
 
-#### If the number of input files is big (cannot be opened all at once)
+#### 2.1.2 If the number of input files is big (cannot be opened all at once)
 
 ```python
 from ivcfmerge import ivcfmerge_batch
@@ -36,10 +40,9 @@ batch_size = 1000    # How many files to open and merge at once
 ivcfmerge_batch(filenames, output_path, batch_size)
 ```
 
-##### You may also need to specify a temporary directory
+##### 2.1.2.1 You may also need to specify a temporary directory
 
-That has at least as much space as that occupied by the input files to store intermediate results, in the batch processing
-version.
+That has at least as much space as that occupied by the input files to store intermediate results, in the batch processing version.
 
 ```python
 ...
@@ -48,18 +51,52 @@ temp_dir = '...'  # for example, a directory on a mounted disk like /mnt/big_dis
 ivcfmerge_batch(filenames, output_path, batch_size, temp_dir)
 ```
 
-## Important parameters
+### <a name="cli-usage">2.2 Command line interface</a>
+
+#### 2.2.1 If the number of input files is small (can be opened all at once)
+
+```shell script
+# Prepare a file of paths to input VCF files
+> cat input_paths.txt
+1.vcf
+2.vcf
+...
+
+> python ivcfmerge.py input_paths.txt path/to/output/file
+```
+
+#### 2.2.2 If the number of input files is big (cannot be opened all at once) 
+
+```shell script
+# Prepare a file of paths to input VCF files
+> cat input_paths.txt
+1.vcf
+2.vcf
+...
+
+> python ivcfmerge_batch.py --batch-size 1000 input_paths.txt path/to/output/file
+```
+
+##### 2.1.2.1 You may also need to specify a temporary directory
+
+That has at least as much space as that occupied by the input files to store intermediate results, in the batch processing version.
+
+```shell script
+...
+
+> python ivcfmerge_batch.py --batch-size 1000 --temp-dir /path/to/tmp/dir input_paths.txt path/to/output/file
+```
+
+## 3. Important parameters
  
-### `batch_size`
+### 3.1 `batch_size`
 
 Indicates how many files to open and merge each batch, for the batch processing version.
 
 The default value for this parameter is 1000.
 
-### `temp_dir`
+### 3.2 `temp_dir`
 
-For the batch processing version, the utility needs to store the intermediate results somewhere with as much space as
-the total space occupied by the input files.
+For the batch processing version, the utility needs to store the intermediate results somewhere with as much space as the total space occupied by the input files.
 
-By default, the choice is left to the [tempfile](https://docs.python.org/3/library/tempfile.html#tempfile.TemporaryFile)
-library. On Unix/Linux, this is usually `/tmp`.
+By default, the choice is left to the [tempfile](https://docs.python.org/3/library/tempfile.html#tempfile.TemporaryFile) library. On Unix/Linux, this is usually `/tmp`.

--- a/ivcfmerge.py
+++ b/ivcfmerge.py
@@ -1,0 +1,17 @@
+import argparse
+from contextlib import ExitStack
+
+from ivcfmerge import ivcfmerge
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('input_paths_file', type=str)
+    parser.add_argument('output_path', type=str)
+    args = parser.parse_args()
+
+    with open(args.input_paths_file, 'r') as input_paths_file:
+        input_paths = input_paths_file.read().splitlines()
+
+        with ExitStack() as stack, open(args.output_path, 'w') as outfile:
+            infiles = map(lambda p: stack.enter_context(open(p)), input_paths)
+            ivcfmerge(infiles, outfile)

--- a/ivcfmerge/batch.py
+++ b/ivcfmerge/batch.py
@@ -4,7 +4,9 @@ from tempfile import NamedTemporaryFile
 from . import ivcfmerge
 
 
-def ivcfmerge_batch(input_paths, output_path, batch_size=1000, temp_dir=None):
+def ivcfmerge_batch(input_paths, output_path, batch_size=None, temp_dir=None):
+    batch_size = batch_size or 1000
+
     if batch_size < 2 or batch_size > len(input_paths):
         batch_size = len(input_paths)
 

--- a/ivcfmerge_batch.py
+++ b/ivcfmerge_batch.py
@@ -1,0 +1,15 @@
+import argparse
+
+from ivcfmerge import ivcfmerge_batch
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--batch-size', type=int)
+    parser.add_argument('--temp-dir', type=str)
+    parser.add_argument('input_paths_file', type=str)
+    parser.add_argument('output_path', type=str)
+    args = parser.parse_args()
+
+    with open(args.input_paths_file, 'r') as input_paths_file:
+        input_paths = input_paths_file.read().splitlines()
+        ivcfmerge_batch(input_paths, args.output_path, args.batch_size, args.temp_dir)

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -1,0 +1,6 @@
+import pytest
+
+
+@pytest.fixture
+def input_paths_file():
+    return 'tests/data/input_paths.txt'

--- a/tests/cli/test_ivcfmerge_batch_cli.py
+++ b/tests/cli/test_ivcfmerge_batch_cli.py
@@ -1,0 +1,34 @@
+import subprocess
+
+from hypothesis import given, strategies as st
+
+
+def test_merging_example_input(input_paths_file, ref_merged_path, tmp_path):
+    output_path = tmp_path / 'out.vcf'
+
+    subprocess.run(['python', 'ivcfmerge_batch.py', input_paths_file, str(output_path)])
+
+    with output_path.open() as outfile, open(ref_merged_path, 'r') as ref_merged:
+        assert outfile.read() == ref_merged.read()
+
+
+@given(batch_size=st.integers())
+def test_batch_sizes(input_paths_file, ref_merged_path, tmp_path, batch_size):
+    output_path = tmp_path / 'out.vcf'
+
+    subprocess.run(['python', 'ivcfmerge_batch.py', '--batch-size', str(batch_size), input_paths_file,
+                    str(output_path)])
+
+    with output_path.open() as outfile, open(ref_merged_path, 'r') as ref_merged:
+        assert outfile.read() == ref_merged.read()
+
+
+@given(batch_size=st.integers())
+def test_temporary_dir(input_paths_file, ref_merged_path, tmp_path, batch_size):
+    output_path = tmp_path / 'out.vcf'
+
+    subprocess.run(['python', 'ivcfmerge_batch.py', '--batch-size', str(batch_size),
+                    '--temp-dir', str(tmp_path), input_paths_file, str(output_path)])
+
+    with output_path.open() as outfile, open(ref_merged_path, 'r') as ref_merged:
+        assert outfile.read() == ref_merged.read()

--- a/tests/cli/test_ivcfmerge_batch_cli.py
+++ b/tests/cli/test_ivcfmerge_batch_cli.py
@@ -6,7 +6,7 @@ from hypothesis import given, strategies as st
 def test_merging_example_input(input_paths_file, ref_merged_path, tmp_path):
     output_path = tmp_path / 'out.vcf'
 
-    subprocess.run(['python', 'ivcfmerge_batch.py', input_paths_file, str(output_path)])
+    subprocess.run(['python3', 'ivcfmerge_batch.py', input_paths_file, str(output_path)])
 
     with output_path.open() as outfile, open(ref_merged_path, 'r') as ref_merged:
         assert outfile.read() == ref_merged.read()
@@ -16,7 +16,7 @@ def test_merging_example_input(input_paths_file, ref_merged_path, tmp_path):
 def test_batch_sizes(input_paths_file, ref_merged_path, tmp_path, batch_size):
     output_path = tmp_path / 'out.vcf'
 
-    subprocess.run(['python', 'ivcfmerge_batch.py', '--batch-size', str(batch_size), input_paths_file,
+    subprocess.run(['python3', 'ivcfmerge_batch.py', '--batch-size', str(batch_size), input_paths_file,
                     str(output_path)])
 
     with output_path.open() as outfile, open(ref_merged_path, 'r') as ref_merged:
@@ -27,7 +27,7 @@ def test_batch_sizes(input_paths_file, ref_merged_path, tmp_path, batch_size):
 def test_temporary_dir(input_paths_file, ref_merged_path, tmp_path, batch_size):
     output_path = tmp_path / 'out.vcf'
 
-    subprocess.run(['python', 'ivcfmerge_batch.py', '--batch-size', str(batch_size),
+    subprocess.run(['python3', 'ivcfmerge_batch.py', '--batch-size', str(batch_size),
                     '--temp-dir', str(tmp_path), input_paths_file, str(output_path)])
 
     with output_path.open() as outfile, open(ref_merged_path, 'r') as ref_merged:

--- a/tests/cli/test_ivcfmerge_cli.py
+++ b/tests/cli/test_ivcfmerge_cli.py
@@ -1,0 +1,10 @@
+import subprocess
+
+
+def test_merging_example_input(input_paths_file, ref_merged_path, tmp_path):
+    output_path = tmp_path / 'out.vcf'
+
+    subprocess.run(['python', 'ivcfmerge.py', input_paths_file, str(output_path)])
+
+    with output_path.open() as outfile, open(ref_merged_path, 'r') as ref_merged:
+        assert outfile.read() == ref_merged.read()

--- a/tests/cli/test_ivcfmerge_cli.py
+++ b/tests/cli/test_ivcfmerge_cli.py
@@ -4,7 +4,7 @@ import subprocess
 def test_merging_example_input(input_paths_file, ref_merged_path, tmp_path):
     output_path = tmp_path / 'out.vcf'
 
-    subprocess.run(['python', 'ivcfmerge.py', input_paths_file, str(output_path)])
+    subprocess.run(['python3', 'ivcfmerge.py', input_paths_file, str(output_path)])
 
     with output_path.open() as outfile, open(ref_merged_path, 'r') as ref_merged:
         assert outfile.read() == ref_merged.read()

--- a/tests/data/input_paths.txt
+++ b/tests/data/input_paths.txt
@@ -1,0 +1,6 @@
+tests/data/input/1.vcf
+tests/data/input/2.vcf
+tests/data/input/3.vcf
+tests/data/input/4.vcf
+tests/data/input/5.vcf
+tests/data/input/6.vcf

--- a/tests/test_ivcfmerge_batch.py
+++ b/tests/test_ivcfmerge_batch.py
@@ -53,7 +53,7 @@ def test_single_input_yields_the_same_output_as_normal_ivcfmerge(batch_size):
     assert output == expected
 
 
-@given(batch_size=st.integers(min_value=2))
+@given(batch_size=st.integers())
 def test_custom_temporary_directory(batch_size, input_paths, ref_merged_path, tmpdir):
     temp_dir = tmpdir.mkdtemp()
 


### PR DESCRIPTION
# ivcfmerge: Incremental VCF merge

## 1. Purpose

We provides a utility to merge a large number of VCF files (possibly too many to open at once) incrementally, that only use almost as much memory as one merged line takes.

## 2. Usage

You can use the utility as either:

* [A Python library](#python-usage)
* [A Python script](#cli-usage)

### <a name="python-usage">2.1 In Python</a>

#### 2.1.1 If the number of input files is small (can be opened all at once)

```python
from contextlib import ExitStack
from ivcfmerge import ivcfmerge

filenames = [...]    # List/iterator of relative/absolute paths to input files
output_path = '...'  # Where to write the merged VCF to

with ExitStack() as stack:
    files = map(lambda fname: stack.enter_context(open(fname)), filenames)
    with open(output_path) as outfile:
        ivcfmerge(files, outfile)
```

#### 2.1.2 If the number of input files is big (cannot be opened all at once)

```python
from ivcfmerge import ivcfmerge_batch

filenames = [...]    # List/iterator of relative/absolute paths to input files
output_path = '...'  # Where to write the merged VCF to
batch_size = 1000    # How many files to open and merge at once

ivcfmerge_batch(filenames, output_path, batch_size)
```

##### 2.1.2.1 You may also need to specify a temporary directory

That has at least as much space as that occupied by the input files to store intermediate results, in the batch processing version.

```python
...
temp_dir = '...'  # for example, a directory on a mounted disk like /mnt/big_disk/tmp or /media/big_disk/tmp

ivcfmerge_batch(filenames, output_path, batch_size, temp_dir)
```

### <a name="cli-usage">2.2 Command line interface</a>

#### 2.2.1 If the number of input files is small (can be opened all at once)

```shell script
# Prepare a file of paths to input VCF files
> cat input_paths.txt
1.vcf
2.vcf
...

> python ivcfmerge.py input_paths.txt path/to/output/file
```

#### 2.2.2 If the number of input files is big (cannot be opened all at once) 

```shell script
# Prepare a file of paths to input VCF files
> cat input_paths.txt
1.vcf
2.vcf
...

> python ivcfmerge_batch.py --batch-size 1000 input_paths.txt path/to/output/file
```

##### 2.1.2.1 You may also need to specify a temporary directory

That has at least as much space as that occupied by the input files to store intermediate results, in the batch processing version.

```shell script
...

> python ivcfmerge_batch.py --batch-size 1000 --temp-dir /path/to/tmp/dir input_paths.txt path/to/output/file
```

## 3. Important parameters
 
### 3.1 `batch_size`

Indicates how many files to open and merge each batch, for the batch processing version.

The default value for this parameter is 1000.

### 3.2 `temp_dir`

For the batch processing version, the utility needs to store the intermediate results somewhere with as much space as the total space occupied by the input files.

By default, the choice is left to the [tempfile](https://docs.python.org/3/library/tempfile.html#tempfile.TemporaryFile) library. On Unix/Linux, this is usually `/tmp`.
